### PR TITLE
Added std::isnan(x) to compile on Ubuntu 16.04 LTS

### DIFF
--- a/src/spatialite/deps/geos/config/linux/x64/geos/platform.h
+++ b/src/spatialite/deps/geos/config/linux/x64/geos/platform.h
@@ -85,7 +85,7 @@ extern "C"
 #endif
 
 #if defined(HAVE_ISNAN)
-# define ISNAN(x) (isnan(x))
+# define ISNAN(x) (std::isnan(x))
 #else
 # if defined(_MSC_VER)
 #  define ISNAN(x) _isnan(x)


### PR DESCRIPTION
This resolves a compiler error trying to compile `node-spatialite` on Ubuntu 16.04.

Patch credit in Issue #16.